### PR TITLE
Test for holding response when sending bill run

### DIFF
--- a/app/controllers/v1/billruns_controller.js
+++ b/app/controllers/v1/billruns_controller.js
@@ -72,6 +72,11 @@ class BillRunsController {
 
       const sentBillRun = await SendBillRun.call(regime, billRun)
 
+      // if the summary is being generated then return the holding response straight away
+      if (sentBillRun.status === 'generating_summary') {
+        return sentBillRun
+      }
+
       // check if any customer changes are waiting to be exported for this region
       const customerFile = await GenerateRegionCustomerFile.call(regime, billRun.region)
       if (customerFile.changesCount > 0) {


### PR DESCRIPTION
An issue was found in test where sending a large bill run while there are pending customer changes returned a 500 error. This was because the holding response isn't a bill run object, just an object containing response data, and therefore doesn't have the object method required for exporting customer changes.

This change checks for the holding response and returns it early, thus fixing the issue.

I haven't included unit testing for the issue as I couldn't determine the best way to test it -- this is something to look at in a future change.